### PR TITLE
Remove wrapper Promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,10 +5,7 @@ const fetch = require('isomorphic-fetch');
 const Package = require('nice-package');
 
 module.exports = moduleName => {
-  return new Promise((resolve, reject) => {
-    return fetch(`${registryUrl}${moduleName}`)
+  return fetch(`${registryUrl}${moduleName}`)
     .then(resp => resp.json())
-    .then(pkgInfo => resolve(new Package(pkgInfo)))
-    .catch(err => reject(err))
-  })
+    .then(pkgInfo => new Package(pkgInfo));
 }


### PR DESCRIPTION
The `fetch()` API already returns a Promise, so you can just recycle that. Plus, let any potential errors fall through to the `.catch()` in the calling code.
